### PR TITLE
Enable dependabot alerts for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "11:11"
+      day: "sunday"


### PR DESCRIPTION
## What does this pull request do?

Enable dependabot alerts for GitHub actions

## Why is this pull request needed?

Currently no checks for new versions of GitHub actions

## How does this pull request work?

Adds dependabot.yml
