### PR TITLE
Fix autoload-dev reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,10 @@
 		}
 	},
 	"autoload-dev": {
-		"NickBeen\\RickAndMortyPhpApi\\Tests\\": "tests"
-	},
+        "psr-4": {
+            "NickBeen\\RickAndMortyPhpApi\\Tests\\": "tests"
+        }
+    },
 	"scripts": {
 		"test": "vendor/bin/phpunit"
 	},


### PR DESCRIPTION
## What does this pull request do?

Fixes the `autoload-dev` reference in the `composer.json` file.

## Why is this pull request needed?

It did not comply with PSR-4 standards.
