### PR TITLE
Update minimum PHP version to PHP 8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Library version
       description: "What version of the library do you have installed?"
-      placeholder: "1.0.0"
+      placeholder: "2.0.0"
     validations:
       required: true
   - type: input
@@ -22,7 +22,7 @@ body:
     attributes:
       label: PHP version
       description: "What version of PHP do you have installed?"
-      placeholder: "8.0.0"
+      placeholder: "8.1.0"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.1, 8.0]
+        php: [8.2, 8.1]
         os: [ubuntu-latest, windows-latest]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Rick and Morty API PHP Client
+# The Rick and Morty API - PHP Client
 
 [![Latest version](https://img.shields.io/packagist/v/nickbeen/rick-and-morty-api-php)](https://packagist.org/packages/nickbeen/rick-and-morty-api-php)
 [![Build status](https://img.shields.io/github/actions/workflow/status/nickbeen/rick-and-morty-api-php/run-tests.yml)](https://packagist.org/packages/nickbeen/rick-and-morty-api-php)
@@ -12,15 +12,14 @@ Get all the information about characters, episodes and locations of Rick and Mor
 
 ## Requirements
 
-* PHP >= 8.0
-* JSON extension (enabled by default since PHP 8.0)
+* PHP >= 8.1
 
 ## Installation
 
 Install the library into your project with Composer.
 
 ```
-composer require nickbeen/rick-and-morty-php-api
+composer require nickbeen/rick-and-morty-php-api --no-dev
 ```
 
 ## Usage
@@ -176,26 +175,26 @@ It is possible to search for characters based on search parameters such as speci
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| Gender::FEMALE() | string | Female |
-| Gender::GENDERLESS() | string | Genderless |
-| Gender::MALE() | string | Male |
-| Gender::UNKNOWN() | string | Unknown |
+| Gender::Female | string | Female |
+| Gender::Genderless | string | Genderless |
+| Gender::Male | string | Male |
+| Gender::Unknown | string | Unknown |
 
 #### Status object
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| Status::ALIVE() | string | Alive |
-| Status::DEAD() | string | Dead |
-| Status::UNKNOWN() | string | Unknown |
+| Status::Alive | string | Alive |
+| Status::Dead | string | Dead |
+| Status::Unknown | string | Unknown |
 
 Retrieve a `Collection` with all alive male Ricks.
 
 ```php
 $characters = new Character();
-$characters->withGender(Gender::MALE())
+$characters->withGender(Gender::Male)
     ->withName('Rick')
-    ->withStatus(Status::ALIVE())
+    ->withStatus(Status::Alive)
     ->get();
 
 foreach ($characters->results as $character) {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,50 @@
+# Upgrade Guide
+
+- [Upgrading to 2.0 from 1.x](#upgrading-to-2.0-from-1.x)
+
+## High Impact Changes
+
+- [Update dependencies](#update-dependencies)
+- [Update enumerations](#update-enumerations)
+
+## Upgrading to 2.0 from 1.x
+
+### Update dependencies
+
+**Likelihood Of Impact: High**
+
+#### PHP 8.1 required
+
+This package now requires PHP 8.1.0 or greater.
+
+#### Composer dependencies
+
+Update the following dependency in your application's `composer.json` file:
+
+- `nickbeen/rick-and-morty-api-php` to `^2.0`
+
+In addition, this will remove the `myclabs/php-enum` dependency as PHP 8.1 adds support for native enumerations.
+
+### Update enumerations
+
+**Likelihood Of Impact: High**
+
+Existing references to either the `Gender` or `Status` object need to be replaced by their new Enumeration object.
+Enum cases are in PascalCase styling as recommended by [PER Coding Style 2.0](https://www.php-fig.org/per/coding-style/).
+
+#### Gender object
+
+| Old value in 1.0     | New value in 2.0   |
+| -------------------- | ------------------ |
+| Gender::FEMALE()     | Gender::Female     |
+| Gender::GENDERLESS() | Gender::Genderless |
+| Gender::MALE()       | Gender::Male       |
+| Gender::UNKNOWN()    | Gender::Unknown    |
+
+#### Status object
+
+| Old value in 1.0  | New value in 2.0 |
+| ----------------- | ---------------- |
+| Status::ALIVE()   | Status::Alive    |
+| Status::DEAD()    | Status::Dead     |
+| Status::UNKNOWN() | Status:: Unknown |

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.0",
+		"php": "^8.1",
 		"ext-json": "*",
 		"guzzlehttp/guzzle": "^7.4",
 		"myclabs/php-enum": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
 		"php": "^8.1",
 		"ext-json": "*",
 		"guzzlehttp/guzzle": "^7.4",
-		"myclabs/php-enum": "^1.8",
-		"netresearch/jsonmapper": "^v4.0"
+		"netresearch/jsonmapper": "^4.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^10.1"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"netresearch/jsonmapper": "^v4.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.5"
+		"phpunit/phpunit": "^10.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Character.php
+++ b/src/Character.php
@@ -10,7 +10,7 @@ class Character extends Base implements CharacterContract
 {
 	public function withGender(Gender $gender): Character
 	{
-		$this->filter['gender'] = strtolower($gender->getValue());
+		$this->filter['gender'] = strtolower($gender->value);
 		return $this;
 	}
 
@@ -28,7 +28,7 @@ class Character extends Base implements CharacterContract
 
 	public function withStatus(Status $status): Character
 	{
-		$this->filter['status'] = strtolower($status->getValue());
+		$this->filter['status'] = strtolower($status->value);
 		return $this;
 	}
 

--- a/src/Dto/Api.php
+++ b/src/Dto/Api.php
@@ -5,11 +5,11 @@ namespace NickBeen\RickAndMortyPhpApi\Dto;
 class Api
 {
 	/** Used to get all the characters */
-	public string $characters;
+	public readonly string $characters;
 
 	/** Used to get all the episodes */
-	public string $episodes;
+	public readonly string $episodes;
 
 	/** Used to get all the locations */
-	public string $locations;
+	public readonly string $locations;
 }

--- a/src/Dto/Character.php
+++ b/src/Dto/Character.php
@@ -5,38 +5,38 @@ namespace NickBeen\RickAndMortyPhpApi\Dto;
 class Character
 {
 	/** The id of the character */
-	public int $id;
+	public readonly int $id;
 
 	/** The name of the character */
-	public string $name;
+	public readonly string $name;
 
 	/** The status of the character ('Alive', 'Dead' or 'unknown') */
-	public string $status;
+	public readonly string $status;
 
 	/** The species of the character */
-	public string $species;
+	public readonly string $species;
 
 	/** The type or subspecies of the character */
-	public string $type;
+	public readonly string $type;
 
 	/** The gender of the character ('Female', 'Male', 'Genderless' or 'unknown') */
-	public string $gender;
+	public readonly string $gender;
 
 	/** Name and link to the character's origin location endpoint */
-	public \NickBeen\RickAndMortyPhpApi\Dto\Character\Origin $origin;
+	public readonly \NickBeen\RickAndMortyPhpApi\Dto\Character\Origin $origin;
 
 	/** Name and link to the character's last known location endpoint */
-	public \NickBeen\RickAndMortyPhpApi\Dto\Character\Location $location;
+	public readonly \NickBeen\RickAndMortyPhpApi\Dto\Character\Location $location;
 
 	/** Link to the character's image. All images are 300x300px and most are medium shots or portraits since they are intended to be used as avatars */
-	public string $image;
+	public readonly string $image;
 
 	/** @var string[] List of episodes in which this character appeared */
-	public array $episode;
+	public readonly array $episode;
 
 	/** Link to the character's own URL endpoint */
-	public string $url;
+	public readonly string $url;
 
 	/** Time at which the character was created in the database */
-	public string $created;
+	public readonly string $created;
 }

--- a/src/Dto/Character/Location.php
+++ b/src/Dto/Character/Location.php
@@ -5,8 +5,8 @@ namespace NickBeen\RickAndMortyPhpApi\Dto\Character;
 class Location
 {
 	/** Name to the character's last known location */
-	public string $name;
+	public readonly string $name;
 
 	/** Url to the character's last known location endpoint */
-	public string $url;
+	public readonly string $url;
 }

--- a/src/Dto/Character/Origin.php
+++ b/src/Dto/Character/Origin.php
@@ -5,8 +5,8 @@ namespace NickBeen\RickAndMortyPhpApi\Dto\Character;
 class Origin
 {
 	/** Name to the character's origin location */
-	public string $name;
+	public readonly string $name;
 
 	/** Url to the character's origin location endpoint */
-	public string $url;
+	public readonly string $url;
 }

--- a/src/Dto/Collection/Info.php
+++ b/src/Dto/Collection/Info.php
@@ -5,14 +5,14 @@ namespace NickBeen\RickAndMortyPhpApi\Dto\Collection;
 class Info
 {
 	/** The length of the response */
-	public int $count;
+	public readonly int $count;
 
 	/** The amount of pages */
-	public int $pages;
+	public readonly int $pages;
 
 	/** Link to the next page (if it exists) */
-	public ?string $next;
+	public readonly ?string $next;
 
 	/** Link to the previous page (if it exists) */
-	public ?string $prev;
+	public readonly ?string $prev;
 }

--- a/src/Dto/Episode.php
+++ b/src/Dto/Episode.php
@@ -5,23 +5,23 @@ namespace NickBeen\RickAndMortyPhpApi\Dto;
 class Episode
 {
 	/** The id of the episode */
-	public int $id;
+	public readonly int $id;
 
 	/** The name of the episode */
-	public string $name;
+	public readonly string $name;
 
 	/** The air date of the episode */
-	public string $air_date;
+	public readonly string $air_date;
 
 	/** The code of the episode */
-	public string $episode;
+	public readonly string $episode;
 
 	/** @var string[] List of characters who have been seen in the episode */
-	public array $characters;
+	public readonly array $characters;
 
 	/** Link to the episode's own endpoint */
-	public string $url;
+	public readonly string $url;
 
 	/** Time at which the episode was created in the database */
-	public string $created;
+	public readonly string $created;
 }

--- a/src/Dto/Location.php
+++ b/src/Dto/Location.php
@@ -5,23 +5,23 @@ namespace NickBeen\RickAndMortyPhpApi\Dto;
 class Location
 {
 	/** The id of the location */
-	public int $id;
+	public readonly int $id;
 
 	/** The name of the location */
-	public string $name;
+	public readonly string $name;
 
 	/** The type of the location */
-	public string $type;
+	public readonly string $type;
 
 	/** The dimension in which the location is located */
-	public string $dimension;
+	public readonly string $dimension;
 
 	/** @var string[] List of characters who have been last seen in the location */
-	public array $residents;
+	public readonly array $residents;
 
 	/** Link to the location's own endpoint */
-	public string $url;
+	public readonly string $url;
 
 	/** Time at which the location was created in the database */
-	public string $created;
+	public readonly string $created;
 }

--- a/src/Enums/Gender.php
+++ b/src/Enums/Gender.php
@@ -2,18 +2,10 @@
 
 namespace NickBeen\RickAndMortyPhpApi\Enums;
 
-use MyCLabs\Enum\Enum;
-
-/**
- * @method static Gender FEMALE()
- * @method static Gender GENDERLESS()
- * @method static Gender MALE()
- * @method static Gender UNKNOWN()
- */
-final class Gender extends Enum
+enum Gender: string
 {
-	private const FEMALE = 'Female';
-	private const GENDERLESS = 'Genderless';
-	private const MALE = 'Male';
-	private const UNKNOWN = 'unknown';
+    case Female = 'Female';
+    case Genderless = 'Genderless';
+    case Male = 'Male';
+    case Unknown = 'Unknown';
 }

--- a/src/Enums/Status.php
+++ b/src/Enums/Status.php
@@ -2,16 +2,9 @@
 
 namespace NickBeen\RickAndMortyPhpApi\Enums;
 
-use MyCLabs\Enum\Enum;
-
-/**
- * @method static Status ALIVE()
- * @method static Status DEAD()
- * @method static Status UNKNOWN()
- */
-final class Status extends Enum
+enum Status: string
 {
-	private const ALIVE = 'Alive';
-	private const DEAD = 'Dead';
-	private const UNKNOWN = 'unknown';
+    case Alive = 'Alive';
+    case Dead = 'Dead';
+    case Unknown = 'Unknown';
 }

--- a/tests/CharacterTest.php
+++ b/tests/CharacterTest.php
@@ -93,7 +93,7 @@ class CharacterTest extends TestCase
 
 		$this->assertIsArray($characters);
 		$this->assertCount(2, $characters);
-		$this->assertEquals(Gender::MALE(), $characters[0]->gender);
+		$this->assertEquals(Gender::Male->value, $characters[0]->gender);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class CharacterTest extends TestCase
 		try {
 			$aliveRicks = (new Character())
 				->withName('Rick')
-				->withStatus(Status::ALIVE())
+				->withStatus(Status::Alive)
 				->get();
 		} catch (NotFoundException) {
 			$aliveRicks = null;


### PR DESCRIPTION
## What does this pull request do?

- Increase minimum PHP version to PHP 8.1
- Implement native enumerations in favor of external dependency
- Add `readonly` modifier to class properties in DTO files

## Why is this pull request needed?

PHP 8.0 isn't actively supported anymore, while PHP 8.1 offers improvements this package could benefit from. 

The external enum dependency is no longer needed as PHP 8.1 offers native support for enumerations. 

The new `readonly` modifier enables class properties to be immutable as DTO properties should be.